### PR TITLE
Fixing "null" product when product_i18n exists but not the product itself

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>Gérer la réécriture d'url</title>
     </descriptive>
-    <version>1.5.6</version>
+    <version>1.5.7</version>
     <author>
         <name>Vincent Lopes, Gilles Bourgeat, Tom Pradat</name>
         <email>vlopes@openstudio.fr, gbourgeat@openstudio.fr, tpradat@openstudio.fr</email>

--- a/Controller/Admin/RewriteUrlAdminController.php
+++ b/Controller/Admin/RewriteUrlAdminController.php
@@ -454,7 +454,8 @@ class RewriteUrlAdminController extends BaseAdminController
         $foldersI18n = FolderI18nQuery::create()->filterByTitle($search, Criteria::LIKE)->limit(10);
         $brandsI18n = BrandI18nQuery::create()->filterByTitle($search, Criteria::LIKE)->limit(10);
 
-        $productsI18n = ProductI18nQuery::create()->filterByTitle($search, Criteria::LIKE)->limit(10);
+        // Search the product translation and check existance in product table
+        $productsI18n = ProductI18nQuery::create()->where(' title LIKE "'. $search .'" AND EXISTS (SELECT 1 FROM product WHERE product_i18n.id = product.id)')->limit(10);
         $productsRef = ProductQuery::create()->filterByRef($search, Criteria::LIKE)->limit(10);
 
         /** @var \Thelia\Model\CategoryI18n $categoryI18n */


### PR DESCRIPTION
Searching for the I18n title of the product then search if the product exists in product table (with its ID). Previously the search throw a 500 HTTP error if I18n title exists but not the product, so ajax search return nothing even if there was results.

Best practice would be to have a foreign key between product_i18n and product.