### PR TITLE
fix: resolve back-office hook templates by active parser extension

### DIFF
--- a/Hook/ConfigurationHook.php
+++ b/Hook/ConfigurationHook.php
@@ -46,9 +46,11 @@ class ConfigurationHook extends BaseHook
 
     public function onModuleConfiguration(HookRenderEvent $event): void
     {
+        $extension = $this->getParser()->getFileExtension();
+
         $event->add(
             $this->render(
-                'RewriteUrl/module-configuration.html.twig',
+                'RewriteUrl/module-configuration.'.$extension,
                 [
                     "isRewritingEnabled" => ConfigQuery::isRewritingEnable()
                 ]
@@ -58,9 +60,11 @@ class ConfigurationHook extends BaseHook
 
     public function onModuleConfigurationJavascript(HookRenderEvent $event): void
     {
+        $extension = $this->getParser()->getFileExtension();
+
         $event->add(
             $this->render(
-                'RewriteUrl/module-configuration-js.html.twig',
+                'RewriteUrl/module-configuration-js.'.$extension,
                 [
                     "isRewritingEnabled" => ConfigQuery::isRewritingEnable()
                 ]
@@ -71,7 +75,7 @@ class ConfigurationHook extends BaseHook
     public function onConfigurationCatalogTop(HookRenderEvent $event): void
     {
         $event->add($this->render(
-            'configuration-catalog.html.twig'
+            'configuration-catalog.'.$this->getParser()->getFileExtension()
         ));
     }
 

--- a/Hook/UrlRewritingTabHook.php
+++ b/Hook/UrlRewritingTabHook.php
@@ -41,6 +41,13 @@ class UrlRewritingTabHook extends BaseHook
 
     public function onTabSeoBottom(HookRenderEvent $event): void
     {
+        // This UI is only implemented for the Twig back office (tab-module.html.twig).
+        // The legacy Smarty back office has no compatible template, so skip rendering
+        // there instead of emitting an "Unknown template" error on every edit page.
+        if ('html.twig' !== $this->getParser()->getFileExtension()) {
+            return;
+        }
+
         // The SEO tab forwards the edited object as `type` + `id`. Fall back to the
         // entity-specific argument so the block keeps rendering on templates that do
         // not forward the type yet.


### PR DESCRIPTION
The configuration and SEO-tab hooks hardcoded the `.html.twig` extension, which only resolves on a Twig back office. On the legacy Smarty back office (active `default` template) this produced "ERR: Unknown template ..." on the module configuration page and on every edit page SEO tab.

- `ConfigurationHook` now builds the template name with the current parser's file extension (`.html` on Smarty, `.html.twig` on Twig).
- `UrlRewritingTabHook` (Twig-only UI) now short-circuits on non-Twig parsers instead of rendering a non-existent Smarty template.