### PR TITLE
fix: 500 on not-rewritten urls page (unknown route admin.configuration)

### DIFF
--- a/templates/backOffice/default-twig/list-notrewritenurls.html.twig
+++ b/templates/backOffice/default-twig/list-notrewritenurls.html.twig
@@ -15,7 +15,7 @@
     <nav aria-label="breadcrumb" class="mb-1">
         <ol class="breadcrumb mb-0">
             <li class="breadcrumb-item"><a href="{{ path('admin.home') }}">{{ 'Home'|trans({}, d) }}</a></li>
-            <li class="breadcrumb-item"><a href="{{ path('admin.configuration') }}">{{ 'Configuration'|trans({}, d) }}</a></li>
+            <li class="breadcrumb-item"><a href="{{ path('admin.configuration.index') }}">{{ 'Configuration'|trans({}, d) }}</a></li>
             <li class="breadcrumb-item active" aria-current="page">{{ 'Not rewriten urls'|trans({}, d) }}</li>
         </ol>
     </nav>


### PR DESCRIPTION
The breadcrumb of `list-notrewritenurls.html.twig` generates a URL for the route `admin.configuration`, which does not exist — the back-office configuration page route is `admin.configuration.index`. Opening **Tools > Not rewritten URLs** (`/admin/list-notrewritenurls`) therefore throws `RouteNotFoundException` and the page answers 500.

Spotted on demo.thelia.net (RewriteUrl 3.0.2 on Thelia 3 beta2).